### PR TITLE
feat: make time formatting configurable

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS: ChangelogSettings = {
   numberOfFilesToShow: 10,
   changelogFilePath: "",
   watchVaultChange: false,
+  formatAsTable: false,
   timeFormatting: "YYYY-MM-DD [at] HH[h]mm",
 };
 
@@ -88,13 +89,19 @@ export default class Changelog extends Plugin {
       )
       .sort((a, b) => (a.stat.mtime < b.stat.mtime ? 1 : -1))
       .slice(0, this.settings.numberOfFilesToShow);
-    let changelogContent = ``;
+
+    let changelogContent = !this.settings.formatAsTable
+      ? ``
+      : `| Title | Date |\n| --- | --- |\n`;
     for (let recentlyEditedFile of recentlyEditedFiles) {
       const humanTime = window
         .moment(recentlyEditedFile.stat.mtime)
         .format(this.settings.timeFormatting);
-      changelogContent += `- ${humanTime} · [[${recentlyEditedFile.basename}]]\n`;
+      changelogContent += !this.settings.formatAsTable
+        ? `- ${humanTime} · [[${recentlyEditedFile.basename}]]\n`
+        : `| [[${recentlyEditedFile.basename}]] | ${humanTime} |\n`;
     }
+
     return changelogContent;
   }
 
@@ -124,6 +131,7 @@ interface ChangelogSettings {
   changelogFilePath: string;
   numberOfFilesToShow: number;
   watchVaultChange: boolean;
+  formatAsTable: boolean;
   timeFormatting: string;
 }
 
@@ -181,6 +189,20 @@ class ChangelogSettingsTab extends PluginSettingTab {
             this.plugin.settings.watchVaultChange = value;
             this.plugin.saveSettings();
             this.plugin.registerWatchVaultEvents();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Format changelog as a table")
+      // .setDesc(
+      //   "Automatically update changelog on any vault change (modification, renaming or deletion of a note)"
+      // )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.formatAsTable)
+          .onChange((value) => {
+            this.plugin.settings.formatAsTable = value;
+            this.plugin.saveSettings();
           })
       );
 

--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS: ChangelogSettings = {
   numberOfFilesToShow: 10,
   changelogFilePath: "",
   watchVaultChange: false,
+  timeFormatting: "YYYY-MM-DD [at] HH[h]mm",
 };
 
 declare global {
@@ -21,6 +22,11 @@ declare global {
     moment: typeof moment;
   }
 }
+
+// This is what Excalidraw does to get multiple lines in setting descriptions
+// https://github.com/zsviczian/obsidian-excalidraw-plugin/blob/d82815c56a3c11058e3d04b13ae4447a37775272/src/utils/Utils.ts#L621
+const fragWithHTML = (html: string) =>
+  createFragment((frag) => (frag.createDiv().innerHTML = html));
 
 export default class Changelog extends Plugin {
   settings: ChangelogSettings;
@@ -84,10 +90,9 @@ export default class Changelog extends Plugin {
       .slice(0, this.settings.numberOfFilesToShow);
     let changelogContent = ``;
     for (let recentlyEditedFile of recentlyEditedFiles) {
-      // TODO: make date format configurable (and validate it)
       const humanTime = window
         .moment(recentlyEditedFile.stat.mtime)
-        .format("YYYY-MM-DD [at] HH[h]mm");
+        .format(this.settings.timeFormatting);
       changelogContent += `- ${humanTime} · [[${recentlyEditedFile.basename}]]\n`;
     }
     return changelogContent;
@@ -119,6 +124,7 @@ interface ChangelogSettings {
   changelogFilePath: string;
   numberOfFilesToShow: number;
   watchVaultChange: boolean;
+  timeFormatting: string;
 }
 
 class ChangelogSettingsTab extends PluginSettingTab {
@@ -177,5 +183,22 @@ class ChangelogSettingsTab extends PluginSettingTab {
             this.plugin.registerWatchVaultEvents();
           })
       );
+
+    new Setting(containerEl)
+      .setName("Time format")
+      .setDesc(
+        fragWithHTML(
+          "Default is YYYY-MM-DD [at] HH[h]mm <br> For more syntax, refer to <a href='https://momentjs.com/docs/#/displaying/format/'>format reference</a>"
+        )
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder("YYYY-MM-DD [at] HH[h]mm")
+          .setValue(String(settings.timeFormatting))
+          .onChange((value) => {
+            settings.timeFormatting = value;
+            this.plugin.saveSettings();
+          });
+      });
   }
 }


### PR DESCRIPTION
Submitted in response to #14 , does not style in table but can get natural date and time like requested with this line 
`Do MMM YYYY [at] hh:mma` in new settings field.

![image](https://github.com/badrbouslikhin/obsidian-vault-changelog/assets/37216503/1b790ae6-08a6-4322-a6cd-29c09543a123)
![image](https://github.com/badrbouslikhin/obsidian-vault-changelog/assets/37216503/cdc8baff-6158-4984-bf0b-3f0f7f54426b)
