### PR TITLE
Add file path used in notice of wrong file path

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -98,7 +98,7 @@ export default class Changelog extends Plugin {
     if (file instanceof TFile) {
       await this.app.vault.modify(file, content);
     } else {
-      new Notice("Couldn't write changelog: check the file path");
+      new Notice(`Couldn't write changelog: check the file path - ${filePath}`);
     }
   }
 


### PR DESCRIPTION
Hello -- first time doing a PR in a open source project so please do offer some feedback about process if I haven't done so correctly. 

I am trying to add changelog to my personal vault and there is an issue with my file path. So I have added a little update to the notice to include the file path that the application is reading so as to help me sort through why my file path cannot be resolved by obsidian. 

<img width="684" alt="image" src="https://github.com/badrbouslikhin/obsidian-vault-changelog/assets/39784288/bdc1edff-89fa-4835-a74c-5d3c66c0ea0d">


I think it is a nice touch from a ux perspective. Right now I am at a bit of a loss as I am unsure what exactly is wrong with my file path. 

Many thanks :)