### PR TITLE
Device Name

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import {
 import type moment from "moment";
 
 const DEFAULT_SETTINGS: ChangelogSettings = {
+  deviceName: undefined,
   numberOfFilesToShow: 10,
   changelogFilePath: "",
   watchVaultChange: false,
@@ -83,12 +84,23 @@ export default class Changelog extends Plugin {
       .sort((a, b) => (a.stat.mtime < b.stat.mtime ? 1 : -1))
       .slice(0, this.settings.numberOfFilesToShow);
     let changelogContent = ``;
+    let deviceNameSnippet = "";
+    
+    if(this.settings.deviceName)
+    {
+      deviceNameSnippet = `- ${this.settings.deviceName}, on`;
+    }
+    else
+    {
+      deviceNameSnippet = "- "
+    }
+
     for (let recentlyEditedFile of recentlyEditedFiles) {
       // TODO: make date format configurable (and validate it)
       const humanTime = window
         .moment(recentlyEditedFile.stat.mtime)
-        .format("YYYY-MM-DD [at] HH[h]mm");
-      changelogContent += `- ${humanTime} · [[${recentlyEditedFile.basename}]]\n`;
+        .format("YYYY-MM-DD, [at] HH[h]mm");
+      changelogContent += `${deviceNameSnippet} ${humanTime} · [[${recentlyEditedFile.basename}]]\n`;
     }
     return changelogContent;
   }
@@ -116,6 +128,7 @@ export default class Changelog extends Plugin {
 }
 
 interface ChangelogSettings {
+  deviceName: string;
   changelogFilePath: string;
   numberOfFilesToShow: number;
   watchVaultChange: boolean;
@@ -177,5 +190,20 @@ class ChangelogSettingsTab extends PluginSettingTab {
             this.plugin.registerWatchVaultEvents();
           })
       );
+
+    new Setting(containerEl)
+      .setName("Device name")
+      .setDesc(
+        "Give this device a unique name to record it against items in the change log."
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder("Example: Work Laptop")
+          .setValue(settings.deviceName)
+          .onChange((value) => {
+            settings.deviceName = value;
+            this.plugin.saveSettings();
+          });
+      })
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -84,11 +84,11 @@ export default class Changelog extends Plugin {
       .sort((a, b) => (a.stat.mtime < b.stat.mtime ? 1 : -1))
       .slice(0, this.settings.numberOfFilesToShow);
     let changelogContent = ``;
-    let deviceNameSnippet = "";
+    let deviceNameSnippet = undefined;
     
     if(this.settings.deviceName)
     {
-      deviceNameSnippet = `- ${this.settings.deviceName}, on`;
+      deviceNameSnippet = `- *${this.settings.deviceName}* on`;
     }
     else
     {
@@ -99,7 +99,7 @@ export default class Changelog extends Plugin {
       // TODO: make date format configurable (and validate it)
       const humanTime = window
         .moment(recentlyEditedFile.stat.mtime)
-        .format("YYYY-MM-DD, [at] HH[h]mm");
+        .format("YYYY-MM-DD [at] HH[h]mm");
       changelogContent += `${deviceNameSnippet} ${humanTime} · [[${recentlyEditedFile.basename}]]\n`;
     }
     return changelogContent;
@@ -163,6 +163,21 @@ class ChangelogSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
+      .setName("Device name")
+      .setDesc(
+        "Give this device a unique name to record it against items in the change log"
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder("Example: Work Laptop")
+          .setValue(settings.deviceName)
+          .onChange((value) => {
+            settings.deviceName = value;
+            this.plugin.saveSettings();
+          });
+      })
+
+    new Setting(containerEl)
       .setName("Number of recent files in changelog")
       .setDesc("Number of most recently edited files to show in the changelog")
       .addText((text) =>
@@ -190,20 +205,5 @@ class ChangelogSettingsTab extends PluginSettingTab {
             this.plugin.registerWatchVaultEvents();
           })
       );
-
-    new Setting(containerEl)
-      .setName("Device name")
-      .setDesc(
-        "Give this device a unique name to record it against items in the change log."
-      )
-      .addText((text) => {
-        text
-          .setPlaceholder("Example: Work Laptop")
-          .setValue(settings.deviceName)
-          .onChange((value) => {
-            settings.deviceName = value;
-            this.plugin.saveSettings();
-          });
-      })
   }
 }


### PR DESCRIPTION
Hi, 

Thanks for your plugin! 

This PR implements a new option in Plugin settings to nominate a name for the current device. If nominated, the name is appended to the start of each row of the changelog. 

I sync my vault with a few friends via the LiveSync plugin, and had the desire to know who updated which files most recently. This works for us because we can choose to not sync the plugin data, which includes the unique Device Name.

I'm not sure if this feature works as well with the official Obsidian Sync - I don't know how plugin data is synced in that case, and whether the Device Name might just get synced around and not remain unique...

Anyway, approve if you think this is useful 😊