### PR TITLE
chore: use latest biome schema URL

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- Replace pinned Biome schema version (`2.4.3`) with `latest` so the schema stays current automatically without manual bumps on each Biome upgrade.

## Test plan

- [x] `bun run lint` passes with updated schema reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)