### PR TITLE
fix: correct build.mjs → build.ts reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Three source files in `src/`:
 
 ## Build System
 
-Configured in `build.mjs` using Bun's native bundler:
+Configured in `build.ts` using Bun's native bundler:
 
 - **Entry point**: `src/main.ts`
 - **Output**: CommonJS (required by Obsidian), `obsidian` marked external


### PR DESCRIPTION
## Summary
- Fix stale `build.mjs` reference to `build.ts` in AGENTS.md

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)