### PR TITLE
ci: attest release-asset build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -22,6 +24,14 @@ jobs:
           bun install
           bun test
           bun run build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Create release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Adds sigstore-backed build provenance attestations to the release workflow per https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations.

## Changes

- Adds `id-token: write` and `attestations: write` to workflow permissions
- Inserts `actions/attest-build-provenance@v3` step between the build and the release publish; attests `main.js`, `manifest.json`, and `styles.css`

## Consumer verification

After the next tagged release:

\`\`\`bash
gh attestation verify main.js -R philoserf/obsidian-vault-changelog
\`\`\`

Attestations don't surface inline on the release page — they live under repo → Actions → Attestations.

## Test plan

- [ ] Merge, then cut next release; confirm release workflow succeeds with the new step
- [ ] Run `gh attestation verify` against the downloaded `main.js` from the new release