### PR TITLE
fix: harden settings load, fix input UX, and add a11y label

### DIFF
--- a/src/changelog.test.ts
+++ b/src/changelog.test.ts
@@ -231,6 +231,30 @@ describe("normalizeLoadedSettings", () => {
     );
     expect(settings.changelogHeading).toBe("# Changelog");
   });
+
+  test("falls back to defaults when known keys have the wrong type", () => {
+    const settings = normalizeLoadedSettings(
+      {
+        changelogPath: 42,
+        excludedFolders: null,
+        changelogHeading: 42,
+        datetimeFormat: 42,
+      },
+      identity,
+    );
+    expect(settings.changelogPath).toBe(DEFAULT_SETTINGS.changelogPath);
+    expect(settings.excludedFolders).toEqual(DEFAULT_SETTINGS.excludedFolders);
+    expect(settings.changelogHeading).toBe(DEFAULT_SETTINGS.changelogHeading);
+    expect(settings.datetimeFormat).toBe(DEFAULT_SETTINGS.datetimeFormat);
+  });
+
+  test("falls back excludedFolders when it contains non-string entries", () => {
+    const settings = normalizeLoadedSettings(
+      { excludedFolders: ["Archive/", 42] },
+      identity,
+    );
+    expect(settings.excludedFolders).toEqual(DEFAULT_SETTINGS.excludedFolders);
+  });
 });
 
 describe("isValidChangelogPath", () => {

--- a/src/changelog.test.ts
+++ b/src/changelog.test.ts
@@ -248,12 +248,21 @@ describe("normalizeLoadedSettings", () => {
     expect(settings.datetimeFormat).toBe(DEFAULT_SETTINGS.datetimeFormat);
   });
 
-  test("falls back excludedFolders when it contains non-string entries", () => {
+  test("falls back for excludedFolders when it contains non-string entries", () => {
     const settings = normalizeLoadedSettings(
       { excludedFolders: ["Archive/", 42] },
       identity,
     );
     expect(settings.excludedFolders).toEqual(DEFAULT_SETTINGS.excludedFolders);
+  });
+
+  test("falls back to defaults when boolean keys have the wrong type", () => {
+    const settings = normalizeLoadedSettings(
+      { autoUpdate: "false", useWikiLinks: "true" },
+      identity,
+    );
+    expect(settings.autoUpdate).toBe(DEFAULT_SETTINGS.autoUpdate);
+    expect(settings.useWikiLinks).toBe(DEFAULT_SETTINGS.useWikiLinks);
   });
 });
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -65,6 +65,10 @@ export function normalizeLoadedSettings(
     if (typeof settings[key] !== "string")
       settings[key] = DEFAULT_SETTINGS[key];
   }
+  for (const key of ["autoUpdate", "useWikiLinks"] as const) {
+    if (typeof settings[key] !== "boolean")
+      settings[key] = DEFAULT_SETTINGS[key];
+  }
   if (
     !Array.isArray(settings.excludedFolders) ||
     !settings.excludedFolders.every((folder) => typeof folder === "string")

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -33,11 +33,13 @@ export function clampMaxRecentFiles(value: unknown): number {
 
 /**
  * Turn persisted data into valid settings: drop unknown keys (so renamed
- * or removed settings don't linger), normalize folder paths so duplicate
- * detection in the settings UI stays consistent, clamp maxRecentFiles,
- * and trim the heading so generateChangelog's "\n\n" spacing stays
- * predictable. `normalize` is injected (Obsidian's normalizePath in
- * production) to keep this module Obsidian-free.
+ * or removed settings don't linger), fall back to defaults for known keys
+ * whose runtime type doesn't match (guards against hand-edited or corrupt
+ * data.json), normalize folder paths so duplicate detection in the
+ * settings UI stays consistent, clamp maxRecentFiles, and trim the
+ * heading so generateChangelog's "\n\n" spacing stays predictable.
+ * `normalize` is injected (Obsidian's normalizePath in production) to
+ * keep this module Obsidian-free.
  */
 export function normalizeLoadedSettings(
   raw: unknown,
@@ -55,6 +57,20 @@ export function normalizeLoadedSettings(
     ...DEFAULT_SETTINGS,
     ...(filtered as Partial<ChangelogSettings>),
   };
+  for (const key of [
+    "changelogPath",
+    "changelogHeading",
+    "datetimeFormat",
+  ] as const) {
+    if (typeof settings[key] !== "string")
+      settings[key] = DEFAULT_SETTINGS[key];
+  }
+  if (
+    !Array.isArray(settings.excludedFolders) ||
+    !settings.excludedFolders.every((folder) => typeof folder === "string")
+  ) {
+    settings.excludedFolders = DEFAULT_SETTINGS.excludedFolders;
+  }
   settings.changelogPath = normalize(settings.changelogPath);
   settings.excludedFolders = settings.excludedFolders.map(normalize);
   settings.maxRecentFiles = clampMaxRecentFiles(settings.maxRecentFiles);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -81,6 +81,7 @@ export class ChangelogSettingsTab extends PluginSettingTab {
       const removeButton = folderDiv.createEl("button", {
         text: "✕",
         cls: "excluded-folder-remove",
+        attr: { "aria-label": "Remove excluded folder" },
       });
 
       removeButton.addEventListener("click", () => {
@@ -161,9 +162,11 @@ export class ChangelogSettingsTab extends PluginSettingTab {
       .setDesc(
         `Maximum number of recently edited files to include (1\u2013${MAX_RECENT_FILES})`,
       )
-      .addText((text) =>
-        text.setValue(settings.maxRecentFiles.toString()).onChange((value) => {
-          const numValue = Number(value);
+      .addText((text) => {
+        text.setValue(settings.maxRecentFiles.toString());
+
+        text.inputEl.addEventListener("blur", () => {
+          const numValue = Number(text.getValue());
           if (Number.isNaN(numValue) || numValue < 1) {
             text.setValue(settings.maxRecentFiles.toString());
             new Notice(
@@ -175,8 +178,8 @@ export class ChangelogSettingsTab extends PluginSettingTab {
           settings.maxRecentFiles = flooredValue;
           text.setValue(flooredValue.toString());
           this.plugin.saveSettingsSafely();
-        }),
-      );
+        });
+      });
 
     new Setting(containerEl)
       .setName("Use wiki-links")


### PR DESCRIPTION
## Summary
- `normalizeLoadedSettings` now falls back to defaults when known keys (`changelogPath`, `changelogHeading`, `datetimeFormat`, `excludedFolders`) have the wrong runtime type, instead of crashing plugin load on a hand-edited or corrupt `data.json` (closes #174).
- "Max recent files" now validates on `blur` instead of `onChange`, matching the existing `changelogPath` field, so clearing the field to retype no longer reverts mid-edit (closes #175).
- Excluded-folder remove button gets an `aria-label` for screen readers (closes #176).

## Test plan
- [x] `bun run check` (typecheck + biome)
- [x] `bun test` (29 tests, including new coverage for the type-fallback behavior)

https://claude.ai/code/session_01WSxsGHCZXmMoCDkNfqgsBr