### PR TITLE
chore: route releases through the gate/ship skills

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bun audit --audit-level=critical
-      - run: bun run check
+      # `build` is check + bundle. The diff then fails the PR when the committed
+      # main.js does not match a fresh build — Obsidian ships the committed
+      # bundle, so a dependency bump that skips the rebuild must not merge.
+      # bun is deliberately unpinned, so a bun release that shifts bundler
+      # output trips this too. The fix is the same either way: rebuild and
+      # commit main.js.
+      - run: bun run build
+      - run: git diff --exit-code main.js
       - run: bun test
-      - run: bun run build.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,7 @@ The plugin has an intentional split between pure logic and Obsidian integration:
 
 ## Release Process
 
-Always merge PRs before tagging. Tags must point to the merged commit on `main`:
-
-```bash
-git tag -a 1.0.0 -m "Release 1.0.0"
-git push origin 1.0.0
-```
-
-The GitHub Actions release workflow builds and publishes the release.
+Use the `obsidian-release-gate` then `obsidian-release-ship` skills — do not tag by hand.
 
 ## Code Style
 


### PR DESCRIPTION
Routes every plugin release through `obsidian-release-gate` + `obsidian-release-ship` instead of a restated procedure in `CLAUDE.md`, and makes CI catch a stale committed `main.js` at PR time.

**Why:** the duplicated prose drifted. Five of seven plugin repos instructed hand-tagging, and `obsidian-publisher` had come to describe `bun run version` as committing and tagging, which `version-bump.ts` does not do. One pointer per repo cannot go stale.

**CI change:** `bun run check` becomes `bun run build` (check + bundle) followed by `git diff --exit-code main.js`. Obsidian distributes the committed bundle, so a dependency PR merging without a rebuild leaves a stale artifact that currently only surfaces at release time.

**bun stays unpinned.** Every project here tracks the latest bun on purpose, so this check will also go red when a bun release shifts bundler output. That is the same signal rather than a false one — `release.yml` builds with the latest bun too, so the committed bundle should match what it would ship. Either way the fix is to rebuild and commit `main.js`.